### PR TITLE
Bugfix: remove Quickplay from track events

### DIFF
--- a/src/metadata-constants.js
+++ b/src/metadata-constants.js
@@ -216,6 +216,8 @@ exports.LIMITED_RANKED_EVENTS = [
 exports.STANDARD_RANKED_EVENTS = ["Ladder", "Traditional_Ladder", "Traditional_Historic_Ladder"];
 
 exports.SINGLE_MATCH_EVENTS = [
+  "Play",
+  "Historic_Play",
   "AIBotMatch",
   "NPE",
   "DirectGame",


### PR DESCRIPTION
This PR updates the non-track events constant so that "Play" and "Historic Play" do not appear on the Events page or in other places where they do not belong.